### PR TITLE
Check for input ref before setting native props

### DIFF
--- a/RCTAutoComplete.ios.js
+++ b/RCTAutoComplete.ios.js
@@ -164,7 +164,7 @@ maximumNumberOfAutoCompleteRows: PropTypes.number,
       // to match.  Most usage shouldn't need this, but if it does this will be
       // more correct but might flicker a bit and/or cause the cursor to jump.
       if (text !== this.props.value && typeof this.props.value === 'string') {
-        this.refs.input.setNativeProps({
+        this.refs.input && this.refs.input.setNativeProps({
           text: this.props.value,
         });
       }


### PR DESCRIPTION
It doesn't look like there are any element with input ref in the code. From the comment, it sounds like there might be some corner case that needs it, so I added a check for the ref existence before calling the method.
