### PR TITLE
cross-platform implementation of textAlign propriety

### DIFF
--- a/RCTAutoComplete.ios.js
+++ b/RCTAutoComplete.ios.js
@@ -100,8 +100,16 @@ autoCapitalize: PropTypes.oneOf([
  * @platorm android
  */
 textAlign: PropTypes.oneOf([
-    'start',
+    // Cross-platform
     'center',
+    // ios only
+    'auto',
+    'center',
+    'justify',
+    'left',
+    'right',
+    // android only
+    'start',
     'end',
     ]),
 


### PR DESCRIPTION
This will remove the "invalid propriety type" error on iOS
