### PR TITLE
Changed the PropType of textAlign

### DIFF
--- a/RCTAutoComplete.ios.js
+++ b/RCTAutoComplete.ios.js
@@ -96,9 +96,11 @@ var RCTAutoComplete = React.createClass({
      * @platorm android
      */
     textAlign: PropTypes.oneOf([
-      'start',
+        'auto',
       'center',
-      'end',
+      'justify',
+      'left',
+      'right'
     ]),
 
     cellComponent: PropTypes.string,


### PR DESCRIPTION
Start, center and end is no longer valid for textAlign. It should be auto, center. justify, left or right.